### PR TITLE
Implement ETFFuture discrete dividend pricing

### DIFF
--- a/beacon/derivatives/__init__.py
+++ b/beacon/derivatives/__init__.py
@@ -1,0 +1,5 @@
+"""Derivative instruments and pricing helpers."""
+
+from .futures import ETFFuture, IndexFuture
+
+__all__ = ["IndexFuture", "ETFFuture"]

--- a/beacon/derivatives/futures.py
+++ b/beacon/derivatives/futures.py
@@ -1,0 +1,59 @@
+"""Future contract models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+from .pricing import continuous_carry_forward_price, discrete_dividend_forward_price
+
+
+@dataclass
+class IndexFuture:
+    """Index future priced with a continuous dividend-yield model."""
+
+    contract_id: str
+    underlying_ticker: str
+    maturity_date: Any
+    market_data: Dict[str, Any] = field(default_factory=dict)
+
+    def fair_value(self) -> float:
+        """Return fair value using continuous cost-of-carry pricing."""
+        spot_price = float(self.market_data["spot_price"])
+        risk_free_rate = float(self.market_data.get("risk_free_rate", 0.0))
+        time_to_maturity = float(self.market_data["time_to_maturity"])
+        dividend_yield = float(self.market_data.get("dividend_yield", 0.0))
+
+        return continuous_carry_forward_price(
+            spot_price=spot_price,
+            risk_free_rate=risk_free_rate,
+            time_to_maturity=time_to_maturity,
+            dividend_yield=dividend_yield,
+        )
+
+
+@dataclass
+class ETFFuture(IndexFuture):
+    """ETF future priced with known discrete ETF dividends when available."""
+
+    def fair_value(self) -> float:
+        """Return fair value using discrete dividends, falling back to yield.
+
+        ``market_data["discrete_dividends"]`` should be a list of
+        ``(time_to_payment, amount)`` pairs where times are in years from the
+        valuation date and amounts are cash dividends per ETF share.
+        """
+        dividends: List[Tuple[float, float]] = self.market_data.get("discrete_dividends") or []
+        if not dividends:
+            return super().fair_value()
+
+        spot_price = float(self.market_data["spot_price"])
+        risk_free_rate = float(self.market_data.get("risk_free_rate", 0.0))
+        time_to_maturity = float(self.market_data["time_to_maturity"])
+
+        return discrete_dividend_forward_price(
+            spot_price=spot_price,
+            risk_free_rate=risk_free_rate,
+            time_to_maturity=time_to_maturity,
+            dividends=dividends,
+        )

--- a/beacon/derivatives/pricing.py
+++ b/beacon/derivatives/pricing.py
@@ -1,0 +1,56 @@
+"""Pricing helpers for derivative instruments."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, Tuple
+
+
+def continuous_carry_forward_price(
+    spot_price: float,
+    risk_free_rate: float,
+    time_to_maturity: float,
+    dividend_yield: float = 0.0,
+) -> float:
+    """Price a forward/future using continuous carry.
+
+    F = S * exp((r - q) * T)
+    """
+    return spot_price * math.exp((risk_free_rate - dividend_yield) * time_to_maturity)
+
+
+def present_value_discrete_dividends(
+    dividends: Iterable[Tuple[float, float]],
+    risk_free_rate: float,
+    time_to_maturity: float,
+) -> float:
+    """Return the present value of known dividends within the contract tenor.
+
+    Each dividend is represented as ``(time_to_payment, amount)`` where time is
+    in years from valuation date. Dividends outside ``time_to_maturity`` are
+    ignored because they do not affect the current futures tenor.
+    """
+    pv = 0.0
+    for payment_time, amount in dividends:
+        if payment_time < 0 or payment_time > time_to_maturity:
+            continue
+        pv += amount * math.exp(-risk_free_rate * payment_time)
+    return pv
+
+
+def discrete_dividend_forward_price(
+    spot_price: float,
+    risk_free_rate: float,
+    time_to_maturity: float,
+    dividends: Iterable[Tuple[float, float]],
+) -> float:
+    """Price a forward/future by subtracting PV(discrete dividends).
+
+    F = (S - PV(divs)) * exp(r * T)
+    """
+    dividend_pv = present_value_discrete_dividends(
+        dividends,
+        risk_free_rate,
+        time_to_maturity,
+    )
+    return (spot_price - dividend_pv) * math.exp(risk_free_rate * time_to_maturity)

--- a/tests/test_derivatives_futures.py
+++ b/tests/test_derivatives_futures.py
@@ -1,0 +1,90 @@
+"""Tests for future contract pricing."""
+
+import math
+
+import pytest
+
+from beacon.derivatives import ETFFuture, IndexFuture
+from beacon.derivatives.pricing import present_value_discrete_dividends
+
+
+def test_etf_future_extends_index_future():
+    assert issubclass(ETFFuture, IndexFuture)
+
+
+def test_index_future_prices_with_continuous_yield_model():
+    future = IndexFuture(
+        contract_id="idx-fut-1",
+        underlying_ticker="SPX",
+        maturity_date="2026-12-31",
+        market_data={
+            "spot_price": 100.0,
+            "risk_free_rate": 0.05,
+            "dividend_yield": 0.02,
+            "time_to_maturity": 1.5,
+        },
+    )
+
+    assert future.fair_value() == pytest.approx(100.0 * math.exp((0.05 - 0.02) * 1.5))
+
+
+def test_etf_future_uses_discrete_dividend_model_when_dividends_are_provided():
+    future = ETFFuture(
+        contract_id="etf-fut-1",
+        underlying_ticker="SPY",
+        maturity_date="2026-12-31",
+        market_data={
+            "spot_price": 100.0,
+            "risk_free_rate": 0.05,
+            "dividend_yield": 0.02,
+            "time_to_maturity": 1.0,
+            "discrete_dividends": [(0.25, 1.0), (0.75, 1.0)],
+        },
+    )
+
+    dividend_pv = present_value_discrete_dividends([(0.25, 1.0), (0.75, 1.0)], 0.05, 1.0)
+    expected = (100.0 - dividend_pv) * math.exp(0.05 * 1.0)
+
+    assert future.fair_value() == pytest.approx(expected)
+    assert future.fair_value() != pytest.approx(100.0 * math.exp((0.05 - 0.02) * 1.0))
+
+
+def test_etf_future_falls_back_to_continuous_yield_model_without_discrete_dividends():
+    market_data = {
+        "spot_price": 100.0,
+        "risk_free_rate": 0.05,
+        "dividend_yield": 0.02,
+        "time_to_maturity": 1.0,
+    }
+    etf_future = ETFFuture(
+        contract_id="etf-fut-2",
+        underlying_ticker="SPY",
+        maturity_date="2026-12-31",
+        market_data=market_data,
+    )
+    index_future = IndexFuture(
+        contract_id="idx-fut-2",
+        underlying_ticker="SPX",
+        maturity_date="2026-12-31",
+        market_data=market_data,
+    )
+
+    assert etf_future.fair_value() == pytest.approx(index_future.fair_value())
+
+
+def test_discrete_dividend_pricing_ignores_dividends_outside_tenor():
+    future = ETFFuture(
+        contract_id="etf-fut-3",
+        underlying_ticker="SPY",
+        maturity_date="2026-12-31",
+        market_data={
+            "spot_price": 100.0,
+            "risk_free_rate": 0.05,
+            "time_to_maturity": 1.0,
+            "discrete_dividends": [(0.5, 1.0), (1.5, 100.0)],
+        },
+    )
+
+    expected = (100.0 - math.exp(-0.05 * 0.5)) * math.exp(0.05)
+
+    assert future.fair_value() == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- Add a derivatives package with IndexFuture and ETFFuture models
- Add pricing helpers for continuous carry and discrete-dividend futures pricing
- Make ETFFuture use `F = (S - PV(divs)) * exp(r * T)` when `market_data["discrete_dividends"]` is provided, with fallback to the continuous yield model otherwise
- Add unit tests covering inheritance, continuous pricing, discrete-vs-continuous behavior, fallback behavior, and tenor filtering for dividends

Refs #44

## Validation
- `pytest tests/test_derivatives_futures.py`
- `pytest`
- `git diff --check`
