### PR TITLE
Implement DerivativeBase abstraction

### DIFF
--- a/beacon/derivatives/__init__.py
+++ b/beacon/derivatives/__init__.py
@@ -1,0 +1,5 @@
+"""Derivative instruments and pricing helpers."""
+
+from .base import DerivativeBase
+
+__all__ = ["DerivativeBase"]

--- a/beacon/derivatives/base.py
+++ b/beacon/derivatives/base.py
@@ -1,0 +1,63 @@
+"""Base abstractions for derivative instruments."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+import pandas as pd
+
+
+class DerivativeBase(ABC):
+    """Abstract base for Delta-1 derivative instruments."""
+
+    def __init__(
+        self,
+        derivative_id: str,
+        underlying_id: str,
+        underlying_type: str,
+        currency: str,
+        expiry_date: str,
+        notional: float,
+    ):
+        if not derivative_id:
+            raise ValueError("derivative_id cannot be empty.")
+        if not underlying_id:
+            raise ValueError("underlying_id cannot be empty.")
+        if not underlying_type:
+            raise ValueError("underlying_type cannot be empty.")
+        if not currency:
+            raise ValueError("currency cannot be empty.")
+        if notional <= 0:
+            raise ValueError("notional must be positive.")
+
+        self.derivative_id = derivative_id
+        self.underlying_id = underlying_id
+        self.underlying_type = underlying_type
+        self.currency = currency
+        self.expiry_date = pd.Timestamp(expiry_date)
+        self.notional = float(notional)
+
+    @abstractmethod
+    def fair_value(
+        self,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        market_data: Dict[str, float],
+    ) -> float:
+        """Return the instrument fair value at the valuation date."""
+
+    @abstractmethod
+    def mark_to_market(
+        self,
+        market_price: float,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        market_data: Dict[str, float],
+    ) -> Dict[str, float]:
+        """Return mark-to-market valuation details."""
+
+    def time_to_expiry(self, valuation_date: pd.Timestamp) -> float:
+        """Time to expiry in years using ACT/365."""
+        valuation_ts = pd.Timestamp(valuation_date)
+        days = (self.expiry_date - valuation_ts).days
+        return max(days, 0) / 365.0

--- a/tests/test_derivative_base.py
+++ b/tests/test_derivative_base.py
@@ -1,0 +1,92 @@
+"""Tests for derivative base abstractions."""
+
+from typing import Dict
+
+import pandas as pd
+import pytest
+
+from beacon.derivatives import DerivativeBase
+
+
+class ConcreteDerivative(DerivativeBase):
+    def fair_value(
+        self,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        market_data: Dict[str, float],
+    ) -> float:
+        return spot_price * self.notional
+
+    def mark_to_market(
+        self,
+        market_price: float,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        market_data: Dict[str, float],
+    ) -> Dict[str, float]:
+        fair_value = self.fair_value(spot_price, valuation_date, market_data)
+        market_value = market_price * self.notional
+        return {"fair_value": fair_value, "market_value": market_value, "pnl": market_value - fair_value}
+
+
+def _derivative(**overrides):
+    kwargs = {
+        "derivative_id": "deriv-1",
+        "underlying_id": "SPY",
+        "underlying_type": "ETF",
+        "currency": "USD",
+        "expiry_date": "2026-01-02",
+        "notional": 100.0,
+    }
+    kwargs.update(overrides)
+    return ConcreteDerivative(**kwargs)
+
+
+def test_derivative_base_cannot_be_instantiated_directly():
+    with pytest.raises(TypeError):
+        DerivativeBase("d", "u", "ETF", "USD", "2026-01-02", 100.0)
+
+
+@pytest.mark.parametrize(
+    "field,value,error",
+    [
+        ("derivative_id", "", "derivative_id"),
+        ("underlying_id", "", "underlying_id"),
+        ("underlying_type", "", "underlying_type"),
+        ("currency", "", "currency"),
+        ("notional", 0.0, "notional"),
+        ("notional", -1.0, "notional"),
+    ],
+)
+def test_construction_validates_required_fields(field, value, error):
+    with pytest.raises(ValueError, match=error):
+        _derivative(**{field: value})
+
+
+def test_construction_stores_required_fields_and_normalizes_types():
+    derivative = _derivative(expiry_date="2026-01-02", notional=25)
+
+    assert derivative.derivative_id == "deriv-1"
+    assert derivative.underlying_id == "SPY"
+    assert derivative.underlying_type == "ETF"
+    assert derivative.currency == "USD"
+    assert derivative.expiry_date == pd.Timestamp("2026-01-02")
+    assert derivative.notional == pytest.approx(25.0)
+
+
+def test_time_to_expiry_uses_act_365_and_floors_after_expiry():
+    derivative = _derivative(expiry_date="2026-01-02")
+
+    assert derivative.time_to_expiry(pd.Timestamp("2025-01-02")) == pytest.approx(365 / 365.0)
+    assert derivative.time_to_expiry(pd.Timestamp("2026-01-03")) == pytest.approx(0.0)
+
+
+def test_subclass_implements_fair_value_and_mark_to_market_contract():
+    derivative = _derivative(notional=10.0)
+
+    assert derivative.fair_value(50.0, pd.Timestamp("2025-01-02"), {}) == pytest.approx(500.0)
+    assert derivative.mark_to_market(52.0, 50.0, pd.Timestamp("2025-01-02"), {}) == {
+        "fair_value": 500.0,
+        "market_value": 520.0,
+        "pnl": 20.0,
+    }


### PR DESCRIPTION
## Summary
- Add `beacon.derivatives` package exports
- Implement `DerivativeBase` as an abstract base class for Delta-1 derivative instruments
- Validate required construction fields and normalize expiry/notional values
- Add ACT/365 `time_to_expiry()` behavior with post-expiry floor at zero
- Add unit tests covering direct-instantiation protection, validation, stored attributes, time-to-expiry, and subclass contracts

Refs #42

## Validation
- `pytest tests/test_derivative_base.py`
- `pytest`
- `git diff --check`
