### PR TITLE
Implement derivative pricing utilities

### DIFF
--- a/beacon/derivatives/__init__.py
+++ b/beacon/derivatives/__init__.py
@@ -1,0 +1,17 @@
+"""Derivative instruments and pricing helpers."""
+
+from .pricing import (
+    cost_of_carry_fair_value,
+    discrete_dividend_fair_value,
+    futures_roll_return,
+    implied_repo_rate,
+    trs_breakeven_spread,
+)
+
+__all__ = [
+    "cost_of_carry_fair_value",
+    "discrete_dividend_fair_value",
+    "implied_repo_rate",
+    "futures_roll_return",
+    "trs_breakeven_spread",
+]

--- a/beacon/derivatives/pricing.py
+++ b/beacon/derivatives/pricing.py
@@ -1,0 +1,113 @@
+"""Stateless pricing utilities for Delta-1 derivatives."""
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+import pandas as pd
+
+
+def _validate_spot(spot: float) -> None:
+    if spot <= 0:
+        raise ValueError("spot must be positive.")
+
+
+def _validate_time(time_to_expiry_years: float) -> None:
+    if time_to_expiry_years < 0:
+        raise ValueError("time_to_expiry_years cannot be negative.")
+
+
+def cost_of_carry_fair_value(
+    spot: float,
+    risk_free_rate: float,
+    dividend_yield: float,
+    time_to_expiry_years: float,
+    borrow_cost: float = 0.0,
+) -> float:
+    """Return fair value from the cost-of-carry model.
+
+    F = S * exp((r - q + c) * T)
+    """
+    _validate_spot(spot)
+    _validate_time(time_to_expiry_years)
+    return spot * math.exp((risk_free_rate - dividend_yield + borrow_cost) * time_to_expiry_years)
+
+
+def discrete_dividend_fair_value(
+    spot: float,
+    risk_free_rate: float,
+    time_to_expiry_years: float,
+    dividends: List[Tuple[float, float]],
+) -> float:
+    """Return fair value with known discrete dividends.
+
+    Dividends are ``(time_to_ex_years, amount)`` pairs. Dividends outside the
+    futures tenor are ignored.
+
+    F = (S - PV(divs)) * exp(r * T)
+    """
+    _validate_spot(spot)
+    _validate_time(time_to_expiry_years)
+    pv_dividends = 0.0
+    for time_to_ex_years, amount in dividends:
+        if time_to_ex_years < 0 or time_to_ex_years > time_to_expiry_years:
+            continue
+        pv_dividends += amount * math.exp(-risk_free_rate * time_to_ex_years)
+    return (spot - pv_dividends) * math.exp(risk_free_rate * time_to_expiry_years)
+
+
+def implied_repo_rate(
+    futures_price: float,
+    spot: float,
+    dividend_yield: float,
+    time_to_expiry_years: float,
+) -> float:
+    """Return implied repo/risk-free rate from a futures price.
+
+    r_implied = (ln(F/S) + q*T) / T
+    """
+    if futures_price <= 0:
+        raise ValueError("futures_price must be positive.")
+    _validate_spot(spot)
+    if time_to_expiry_years <= 0:
+        raise ValueError("time_to_expiry_years must be positive.")
+    return (math.log(futures_price / spot) + dividend_yield * time_to_expiry_years) / time_to_expiry_years
+
+
+def futures_roll_return(
+    front_price: float,
+    back_price: float,
+    front_expiry: pd.Timestamp,
+    back_expiry: pd.Timestamp,
+) -> float:
+    """Return annualised roll return from front to back futures contracts."""
+    if front_price <= 0:
+        raise ValueError("front_price must be positive.")
+    if back_price <= 0:
+        raise ValueError("back_price must be positive.")
+    front_ts = pd.Timestamp(front_expiry)
+    back_ts = pd.Timestamp(back_expiry)
+    days_between = (back_ts - front_ts).days
+    if days_between <= 0:
+        raise ValueError("back_expiry must be after front_expiry.")
+    return (front_price / back_price - 1.0) * (365.0 / days_between)
+
+
+def trs_breakeven_spread(
+    futures_price: float,
+    spot: float,
+    risk_free_rate: float,
+    time_to_expiry_years: float,
+    dividend_yield: float,
+) -> float:
+    """Return spread at which TRS economics equal futures economics.
+
+    Solves for ``s`` in ``F = S * exp((r + s - q) * T)``.
+    """
+    if futures_price <= 0:
+        raise ValueError("futures_price must be positive.")
+    _validate_spot(spot)
+    if time_to_expiry_years <= 0:
+        raise ValueError("time_to_expiry_years must be positive.")
+    implied_rate = implied_repo_rate(futures_price, spot, dividend_yield, time_to_expiry_years)
+    return implied_rate - risk_free_rate

--- a/tests/test_derivative_pricing.py
+++ b/tests/test_derivative_pricing.py
@@ -1,0 +1,81 @@
+"""Tests for stateless derivative pricing utilities."""
+
+import math
+
+import pandas as pd
+import pytest
+
+from beacon.derivatives.pricing import (
+    cost_of_carry_fair_value,
+    discrete_dividend_fair_value,
+    futures_roll_return,
+    implied_repo_rate,
+    trs_breakeven_spread,
+)
+
+
+def test_cost_of_carry_fair_value_matches_textbook_formula():
+    assert cost_of_carry_fair_value(100.0, 0.05, 0.02, 1.5, borrow_cost=0.01) == pytest.approx(
+        100.0 * math.exp((0.05 - 0.02 + 0.01) * 1.5)
+    )
+
+
+def test_cost_of_carry_handles_zero_time_and_negative_rates():
+    assert cost_of_carry_fair_value(100.0, -0.01, 0.0, 0.0) == pytest.approx(100.0)
+    assert cost_of_carry_fair_value(100.0, -0.01, 0.0, 1.0) < 100.0
+
+
+def test_discrete_dividend_fair_value_matches_present_value_formula():
+    dividends = [(0.25, 1.0), (0.75, 1.5)]
+    pv_divs = 1.0 * math.exp(-0.04 * 0.25) + 1.5 * math.exp(-0.04 * 0.75)
+
+    assert discrete_dividend_fair_value(100.0, 0.04, 1.0, dividends) == pytest.approx(
+        (100.0 - pv_divs) * math.exp(0.04)
+    )
+
+
+def test_discrete_dividend_fair_value_ignores_dividends_outside_tenor():
+    assert discrete_dividend_fair_value(100.0, 0.05, 1.0, [(-0.1, 100.0), (0.5, 1.0), (2.0, 100.0)]) == pytest.approx(
+        (100.0 - math.exp(-0.05 * 0.5)) * math.exp(0.05)
+    )
+
+
+def test_implied_repo_rate_inverts_cost_of_carry_formula():
+    futures = cost_of_carry_fair_value(100.0, 0.045, 0.015, 2.0)
+
+    assert implied_repo_rate(futures, 100.0, 0.015, 2.0) == pytest.approx(0.045)
+
+
+def test_futures_roll_return_annualizes_price_spread_between_expiries():
+    assert futures_roll_return(99.0, 101.0, pd.Timestamp("2025-03-31"), pd.Timestamp("2025-06-30")) == pytest.approx(
+        (99.0 / 101.0 - 1.0) * (365.0 / 91.0)
+    )
+
+
+def test_trs_breakeven_spread_matches_implied_repo_minus_risk_free_rate():
+    futures = cost_of_carry_fair_value(100.0, 0.05, 0.02, 1.0, borrow_cost=0.0075)
+
+    assert trs_breakeven_spread(futures, 100.0, 0.05, 1.0, 0.02) == pytest.approx(0.0075)
+
+
+@pytest.mark.parametrize(
+    "func,args",
+    [
+        (cost_of_carry_fair_value, (0.0, 0.05, 0.02, 1.0)),
+        (discrete_dividend_fair_value, (0.0, 0.05, 1.0, [])),
+        (implied_repo_rate, (100.0, 0.0, 0.02, 1.0)),
+        (trs_breakeven_spread, (100.0, 0.0, 0.05, 1.0, 0.02)),
+    ],
+)
+def test_zero_spot_rejected(func, args):
+    with pytest.raises(ValueError):
+        func(*args)
+
+
+def test_time_and_expiry_edge_cases_rejected():
+    with pytest.raises(ValueError):
+        cost_of_carry_fair_value(100.0, 0.05, 0.02, -1.0)
+    with pytest.raises(ValueError):
+        implied_repo_rate(100.0, 100.0, 0.02, 0.0)
+    with pytest.raises(ValueError):
+        futures_roll_return(100.0, 101.0, pd.Timestamp("2025-06-30"), pd.Timestamp("2025-03-31"))


### PR DESCRIPTION
## Summary
- Add stateless Delta-1 derivative pricing utilities
- Implement cost-of-carry, discrete-dividend fair value, implied repo rate, annualized futures roll return, and TRS breakeven spread helpers
- Export the helpers from `beacon.derivatives`
- Add textbook/hand-calculated tests plus edge cases for zero time, zero spot, negative rates, and invalid expiry order

Refs #41

## Validation
- `pytest tests/test_derivative_pricing.py`
- `pytest`
- `git diff --check`
