### PR TITLE
Implement IndexFuture analytics

### DIFF
--- a/beacon/derivatives/__init__.py
+++ b/beacon/derivatives/__init__.py
@@ -1,0 +1,6 @@
+"""Derivative instruments and pricing helpers."""
+
+from .futures import IndexFuture
+from .pricing import cost_of_carry_fair_value
+
+__all__ = ["IndexFuture", "cost_of_carry_fair_value"]

--- a/beacon/derivatives/futures.py
+++ b/beacon/derivatives/futures.py
@@ -1,0 +1,118 @@
+"""Futures contract models."""
+from __future__ import annotations
+
+import math
+from typing import Dict
+
+import pandas as pd
+
+from .pricing import cost_of_carry_fair_value
+
+
+class IndexFuture:
+    """Index futures contract with cost-of-carry pricing and basis analytics."""
+
+    def __init__(
+        self,
+        derivative_id: str,
+        underlying_id: str,
+        currency: str,
+        expiry_date: str,
+        contract_multiplier: float,
+        tick_size: float,
+        tick_value: float,
+    ):
+        if not derivative_id:
+            raise ValueError("derivative_id cannot be empty.")
+        if not underlying_id:
+            raise ValueError("underlying_id cannot be empty.")
+        if not currency:
+            raise ValueError("currency cannot be empty.")
+        if contract_multiplier <= 0:
+            raise ValueError("contract_multiplier must be positive.")
+        if tick_size <= 0:
+            raise ValueError("tick_size must be positive.")
+        if tick_value <= 0:
+            raise ValueError("tick_value must be positive.")
+
+        self.derivative_id = derivative_id
+        self.underlying_id = underlying_id
+        self.currency = currency
+        self.expiry_date = pd.Timestamp(expiry_date)
+        self.contract_multiplier = float(contract_multiplier)
+        self.tick_size = float(tick_size)
+        self.tick_value = float(tick_value)
+
+    def time_to_expiry(self, valuation_date: pd.Timestamp) -> float:
+        """Return ACT/365 years to expiry, floored at zero after expiry."""
+        days = (self.expiry_date - pd.Timestamp(valuation_date)).days
+        return max(days, 0) / 365.0
+
+    def fair_value(
+        self,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        risk_free_rate: float,
+        dividend_yield: float = 0.0,
+        borrow_cost: float = 0.0,
+    ) -> float:
+        """Return cost-of-carry fair value for the contract."""
+        return cost_of_carry_fair_value(
+            spot=spot_price,
+            risk_free_rate=risk_free_rate,
+            dividend_yield=dividend_yield,
+            borrow_cost=borrow_cost,
+            time_to_expiry_years=self.time_to_expiry(valuation_date),
+        )
+
+    def basis(self, futures_price: float, spot_price: float) -> float:
+        """Return futures basis: futures price minus spot price."""
+        return futures_price - spot_price
+
+    def annualised_basis(self, futures_price: float, spot_price: float, valuation_date: pd.Timestamp) -> float:
+        """Return implied financing rate ln(F/S) / T."""
+        if futures_price <= 0:
+            raise ValueError("futures_price must be positive.")
+        if spot_price <= 0:
+            raise ValueError("spot_price must be positive.")
+        time_to_expiry = self.time_to_expiry(valuation_date)
+        if time_to_expiry == 0:
+            return 0.0
+        return math.log(futures_price / spot_price) / time_to_expiry
+
+    def daily_settlement_pnl(
+        self,
+        settle_today: float,
+        settle_yesterday: float,
+        contracts: int = 1,
+    ) -> float:
+        """Return daily settlement P&L for a contract position."""
+        return (settle_today - settle_yesterday) * self.contract_multiplier * contracts
+
+    def roll_cost(self, front_price: float, back_price: float) -> float:
+        """Return the price cost of rolling from front to back futures."""
+        return back_price - front_price
+
+    def mark_to_market(
+        self,
+        futures_price: float,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        risk_free_rate: float,
+        dividend_yield: float = 0.0,
+        borrow_cost: float = 0.0,
+    ) -> Dict[str, float]:
+        """Return fair value, basis, theoretical edge, and time to expiry."""
+        fair_value = self.fair_value(
+            spot_price=spot_price,
+            valuation_date=valuation_date,
+            risk_free_rate=risk_free_rate,
+            dividend_yield=dividend_yield,
+            borrow_cost=borrow_cost,
+        )
+        return {
+            "fair_value": fair_value,
+            "basis": self.basis(futures_price, spot_price),
+            "theoretical_edge": futures_price - fair_value,
+            "time_to_expiry": self.time_to_expiry(valuation_date),
+        }

--- a/beacon/derivatives/pricing.py
+++ b/beacon/derivatives/pricing.py
@@ -1,0 +1,19 @@
+"""Pricing helpers for Delta-1 derivative instruments."""
+from __future__ import annotations
+
+import math
+
+
+def cost_of_carry_fair_value(
+    spot: float,
+    risk_free_rate: float,
+    dividend_yield: float,
+    time_to_expiry_years: float,
+    borrow_cost: float = 0.0,
+) -> float:
+    """Return futures fair value using F = S * exp((r - q + c) * T)."""
+    if spot <= 0:
+        raise ValueError("spot must be positive.")
+    if time_to_expiry_years < 0:
+        raise ValueError("time_to_expiry_years cannot be negative.")
+    return spot * math.exp((risk_free_rate - dividend_yield + borrow_cost) * time_to_expiry_years)

--- a/tests/test_index_future.py
+++ b/tests/test_index_future.py
@@ -1,0 +1,111 @@
+"""Tests for IndexFuture pricing and analytics."""
+
+import math
+
+import pandas as pd
+import pytest
+
+from beacon.derivatives import IndexFuture
+from beacon.derivatives.pricing import cost_of_carry_fair_value
+
+
+def _future(**overrides):
+    kwargs = {
+        "derivative_id": "ifut-1",
+        "underlying_id": "SPX",
+        "currency": "USD",
+        "expiry_date": "2026-01-02",
+        "contract_multiplier": 50.0,
+        "tick_size": 0.25,
+        "tick_value": 12.5,
+    }
+    kwargs.update(overrides)
+    return IndexFuture(**kwargs)
+
+
+def test_constructor_stores_contract_terms():
+    future = _future()
+
+    assert future.derivative_id == "ifut-1"
+    assert future.underlying_id == "SPX"
+    assert future.currency == "USD"
+    assert future.expiry_date == pd.Timestamp("2026-01-02")
+    assert future.contract_multiplier == pytest.approx(50.0)
+    assert future.tick_size == pytest.approx(0.25)
+    assert future.tick_value == pytest.approx(12.5)
+
+
+def test_fair_value_uses_cost_of_carry_pricing_helper():
+    future = _future(expiry_date="2026-07-02")
+    valuation_date = pd.Timestamp("2025-01-02")
+    time_to_expiry = future.time_to_expiry(valuation_date)
+
+    assert future.fair_value(5000.0, valuation_date, 0.05, 0.015, 0.002) == pytest.approx(
+        cost_of_carry_fair_value(5000.0, 0.05, 0.015, time_to_expiry, 0.002)
+    )
+
+
+def test_fair_value_at_expiry_returns_spot_price():
+    future = _future(expiry_date="2026-01-02")
+
+    assert future.fair_value(5000.0, pd.Timestamp("2026-01-02"), 0.05, 0.02) == pytest.approx(5000.0)
+
+
+def test_basis_and_deep_backwardation():
+    future = _future()
+
+    assert future.basis(4700.0, 5000.0) == pytest.approx(-300.0)
+    assert future.annualised_basis(4700.0, 5000.0, pd.Timestamp("2025-01-02")) < 0.0
+
+
+def test_annualised_basis_matches_log_f_over_s_over_t():
+    future = _future(expiry_date="2026-01-02")
+    valuation_date = pd.Timestamp("2025-01-02")
+    time_to_expiry = future.time_to_expiry(valuation_date)
+
+    assert future.annualised_basis(5100.0, 5000.0, valuation_date) == pytest.approx(
+        math.log(5100.0 / 5000.0) / time_to_expiry
+    )
+
+
+def test_annualised_basis_returns_zero_at_expiry():
+    assert _future(expiry_date="2026-01-02").annualised_basis(5100.0, 5000.0, pd.Timestamp("2026-01-02")) == pytest.approx(0.0)
+
+
+def test_daily_settlement_pnl_uses_multiplier_and_contracts():
+    assert _future(contract_multiplier=50.0).daily_settlement_pnl(5100.0, 5080.0, contracts=3) == pytest.approx(3000.0)
+    assert _future(contract_multiplier=50.0).daily_settlement_pnl(5080.0, 5100.0, contracts=2) == pytest.approx(-2000.0)
+
+
+def test_roll_cost_is_back_minus_front():
+    assert _future().roll_cost(5000.0, 5025.0) == pytest.approx(25.0)
+    assert _future().roll_cost(5025.0, 5000.0) == pytest.approx(-25.0)
+
+
+def test_mark_to_market_returns_expected_metrics():
+    future = _future(expiry_date="2026-01-02")
+    valuation_date = pd.Timestamp("2025-01-02")
+    fair_value = future.fair_value(5000.0, valuation_date, 0.05, 0.02)
+
+    mtm = future.mark_to_market(5125.0, 5000.0, valuation_date, 0.05, 0.02)
+
+    assert mtm["fair_value"] == pytest.approx(fair_value)
+    assert mtm["basis"] == pytest.approx(125.0)
+    assert mtm["theoretical_edge"] == pytest.approx(5125.0 - fair_value)
+    assert mtm["time_to_expiry"] == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("derivative_id", ""),
+        ("underlying_id", ""),
+        ("currency", ""),
+        ("contract_multiplier", 0.0),
+        ("tick_size", 0.0),
+        ("tick_value", 0.0),
+    ],
+)
+def test_constructor_rejects_invalid_contract_terms(field, value):
+    with pytest.raises(ValueError):
+        _future(**{field: value})


### PR DESCRIPTION
## Summary
- Add `IndexFuture` with cost-of-carry fair value, basis, annualised basis, settlement P&L, roll cost, and mark-to-market analytics
- Add a focused `cost_of_carry_fair_value()` pricing helper used internally by the future model
- Export the derivatives package API
- Add tests covering all requested methods, known-value calculations, expiry behavior, deep backwardation, and invalid contract terms

Refs #43

## Validation
- `pytest tests/test_index_future.py`
- `pytest`
- `git diff --check`
