### PR TITLE
Implement TotalReturnSwap model

### DIFF
--- a/beacon/derivatives/__init__.py
+++ b/beacon/derivatives/__init__.py
@@ -1,0 +1,6 @@
+"""Derivative instruments."""
+
+from .base import DerivativeBase
+from .swaps import TotalReturnSwap
+
+__all__ = ["DerivativeBase", "TotalReturnSwap"]

--- a/beacon/derivatives/base.py
+++ b/beacon/derivatives/base.py
@@ -1,0 +1,44 @@
+"""Base abstractions for derivative instruments."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+import pandas as pd
+
+
+class DerivativeBase(ABC):
+    """Abstract base for derivative instruments."""
+
+    def __init__(self, derivative_id: str, underlying_id: str, currency: str, expiry_date: str, notional: float):
+        if not derivative_id:
+            raise ValueError("derivative_id cannot be empty.")
+        if not underlying_id:
+            raise ValueError("underlying_id cannot be empty.")
+        if not currency:
+            raise ValueError("currency cannot be empty.")
+        if notional <= 0:
+            raise ValueError("notional must be positive.")
+        self.derivative_id = derivative_id
+        self.underlying_id = underlying_id
+        self.currency = currency
+        self.expiry_date = pd.Timestamp(expiry_date)
+        self.notional = float(notional)
+
+    @abstractmethod
+    def fair_value(self, spot_price: float, valuation_date: pd.Timestamp, market_data: Dict[str, float]) -> float:
+        """Return fair value at the valuation date."""
+
+    @abstractmethod
+    def mark_to_market(
+        self,
+        market_price: float,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        market_data: Dict[str, float],
+    ) -> Dict[str, float]:
+        """Return mark-to-market details."""
+
+    def accrued_days(self, start_date: pd.Timestamp, end_date: pd.Timestamp) -> int:
+        """Return non-negative ACT day count between two dates."""
+        return max((pd.Timestamp(end_date) - pd.Timestamp(start_date)).days, 0)

--- a/beacon/derivatives/swaps.py
+++ b/beacon/derivatives/swaps.py
@@ -1,0 +1,83 @@
+"""Swap derivative models."""
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from .base import DerivativeBase
+
+
+class TotalReturnSwap(DerivativeBase):
+    """Total return swap on an index or equity basket."""
+
+    def __init__(
+        self,
+        derivative_id: str,
+        underlying_id: str,
+        currency: str,
+        start_date: str,
+        end_date: str,
+        notional: float,
+        spread_bps: float,
+        reference_rate: float,
+        payment_frequency: str,
+        reset_type: str = "UNFUNDED",
+    ):
+        super().__init__(derivative_id, underlying_id, currency, end_date, notional)
+        if not payment_frequency:
+            raise ValueError("payment_frequency cannot be empty.")
+        if reset_type not in {"UNFUNDED", "FUNDED"}:
+            raise ValueError("reset_type must be 'UNFUNDED' or 'FUNDED'.")
+        self.start_date = pd.Timestamp(start_date)
+        if self.expiry_date <= self.start_date:
+            raise ValueError("end_date must be after start_date.")
+        self.spread_bps = float(spread_bps)
+        self.reference_rate = float(reference_rate)
+        self.payment_frequency = payment_frequency
+        self.reset_type = reset_type
+
+    @property
+    def spread_rate(self) -> float:
+        """Return contractual spread as a decimal rate."""
+        return self.spread_bps / 10000.0
+
+    def financing_cost(self, valuation_date: pd.Timestamp, last_reset_date: pd.Timestamp, reference_rate: float) -> float:
+        """Return accrued financing cost since last reset using ACT/365."""
+        accrued_days = self.accrued_days(last_reset_date, valuation_date)
+        return self.notional * (reference_rate + self.spread_rate) * accrued_days / 365.0
+
+    def total_return_leg(self, spot_price: float, initial_spot_price: float) -> float:
+        """Return receiver total-return leg P&L."""
+        if initial_spot_price <= 0:
+            raise ValueError("initial_spot_price must be positive.")
+        return self.notional * (spot_price / initial_spot_price - 1.0)
+
+    def fair_value(self, spot_price: float, valuation_date: pd.Timestamp, market_data: Dict[str, float]) -> float:
+        """Return receiver P&L net of accrued financing."""
+        initial_spot_price = market_data["initial_spot_price"]
+        last_reset_date = market_data.get("last_reset_date", self.start_date)
+        reference_rate = market_data.get("reference_rate", self.reference_rate)
+        total_return_leg = self.total_return_leg(spot_price, initial_spot_price)
+        accrued_financing = self.financing_cost(valuation_date, last_reset_date, reference_rate)
+        return total_return_leg - accrued_financing
+
+    def mark_to_market(
+        self,
+        market_price: float,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        market_data: Dict[str, float],
+    ) -> Dict[str, float]:
+        """Return total return leg, financing leg, net MTM, and accrued days."""
+        initial_spot_price = market_data["initial_spot_price"]
+        last_reset_date = market_data.get("last_reset_date", self.start_date)
+        reference_rate = market_data.get("reference_rate", self.reference_rate)
+        total_return_leg = self.total_return_leg(spot_price, initial_spot_price)
+        financing_leg = self.financing_cost(valuation_date, last_reset_date, reference_rate)
+        return {
+            "total_return_leg": total_return_leg,
+            "financing_leg": financing_leg,
+            "net_mtm": total_return_leg - financing_leg,
+            "accrued_days": self.accrued_days(last_reset_date, valuation_date),
+        }

--- a/tests/test_total_return_swap.py
+++ b/tests/test_total_return_swap.py
@@ -1,0 +1,136 @@
+"""Tests for TotalReturnSwap economics."""
+
+import pandas as pd
+import pytest
+
+from beacon.derivatives import DerivativeBase, TotalReturnSwap
+
+
+def _swap(**overrides):
+    kwargs = {
+        "derivative_id": "trs-1",
+        "underlying_id": "SPX",
+        "currency": "USD",
+        "start_date": "2025-01-02",
+        "end_date": "2026-01-02",
+        "notional": 1_000_000.0,
+        "spread_bps": 25.0,
+        "reference_rate": 0.05,
+        "payment_frequency": "QUARTERLY",
+    }
+    kwargs.update(overrides)
+    return TotalReturnSwap(**kwargs)
+
+
+def test_total_return_swap_extends_derivative_base_and_stores_terms():
+    swap = _swap(reset_type="FUNDED")
+
+    assert isinstance(swap, DerivativeBase)
+    assert swap.derivative_id == "trs-1"
+    assert swap.underlying_id == "SPX"
+    assert swap.currency == "USD"
+    assert swap.start_date == pd.Timestamp("2025-01-02")
+    assert swap.expiry_date == pd.Timestamp("2026-01-02")
+    assert swap.notional == pytest.approx(1_000_000.0)
+    assert swap.spread_rate == pytest.approx(0.0025)
+    assert swap.reference_rate == pytest.approx(0.05)
+    assert swap.payment_frequency == "QUARTERLY"
+    assert swap.reset_type == "FUNDED"
+
+
+def test_financing_cost_accrues_with_act_365_day_count():
+    swap = _swap(notional=1_000_000.0, spread_bps=50.0)
+
+    assert swap.financing_cost(pd.Timestamp("2025-04-02"), pd.Timestamp("2025-01-02"), 0.04) == pytest.approx(
+        1_000_000.0 * (0.04 + 0.005) * 90 / 365.0
+    )
+
+
+def test_fair_value_is_total_return_leg_less_accrued_financing():
+    swap = _swap(notional=1_000_000.0, spread_bps=25.0, reference_rate=0.05)
+
+    value = swap.fair_value(
+        spot_price=110.0,
+        valuation_date=pd.Timestamp("2025-04-02"),
+        market_data={"initial_spot_price": 100.0, "last_reset_date": pd.Timestamp("2025-01-02")},
+    )
+
+    expected_total_return = 1_000_000.0 * (110.0 / 100.0 - 1.0)
+    expected_financing = 1_000_000.0 * (0.05 + 0.0025) * 90 / 365.0
+    assert value == pytest.approx(expected_total_return - expected_financing)
+
+
+def test_fair_value_can_be_negative_when_financing_exceeds_return():
+    swap = _swap(notional=1_000_000.0, spread_bps=100.0, reference_rate=0.08)
+
+    value = swap.fair_value(
+        spot_price=99.0,
+        valuation_date=pd.Timestamp("2025-04-02"),
+        market_data={"initial_spot_price": 100.0},
+    )
+
+    assert value < 0.0
+
+
+def test_mark_to_market_returns_requested_components():
+    swap = _swap(notional=500_000.0, spread_bps=30.0, reference_rate=0.04)
+
+    mtm = swap.mark_to_market(
+        market_price=0.0,
+        spot_price=105.0,
+        valuation_date=pd.Timestamp("2025-02-01"),
+        market_data={"initial_spot_price": 100.0, "last_reset_date": pd.Timestamp("2025-01-02")},
+    )
+
+    expected_total_return = 500_000.0 * 0.05
+    expected_financing = 500_000.0 * (0.04 + 0.003) * 30 / 365.0
+    assert mtm == {
+        "total_return_leg": pytest.approx(expected_total_return),
+        "financing_leg": pytest.approx(expected_financing),
+        "net_mtm": pytest.approx(expected_total_return - expected_financing),
+        "accrued_days": 30,
+    }
+
+
+def test_mark_to_market_uses_market_data_reference_rate_override():
+    swap = _swap(reference_rate=0.01, spread_bps=0.0)
+
+    mtm = swap.mark_to_market(
+        market_price=0.0,
+        spot_price=100.0,
+        valuation_date=pd.Timestamp("2025-02-01"),
+        market_data={
+            "initial_spot_price": 100.0,
+            "last_reset_date": pd.Timestamp("2025-01-02"),
+            "reference_rate": 0.06,
+        },
+    )
+
+    assert mtm["financing_leg"] == pytest.approx(1_000_000.0 * 0.06 * 30 / 365.0)
+    assert mtm["net_mtm"] == pytest.approx(-mtm["financing_leg"])
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("derivative_id", ""),
+        ("underlying_id", ""),
+        ("currency", ""),
+        ("notional", 0.0),
+        ("payment_frequency", ""),
+        ("reset_type", "BAD"),
+    ],
+)
+def test_constructor_rejects_invalid_inputs(field, value):
+    with pytest.raises(ValueError):
+        _swap(**{field: value})
+
+
+def test_constructor_rejects_end_date_before_start_date():
+    with pytest.raises(ValueError, match="end_date"):
+        _swap(end_date="2024-12-31")
+
+
+def test_total_return_leg_rejects_non_positive_initial_spot():
+    with pytest.raises(ValueError, match="initial_spot_price"):
+        _swap().total_return_leg(100.0, 0.0)


### PR DESCRIPTION
## Summary
- Add a derivatives package with `DerivativeBase` and `TotalReturnSwap`
- Model TRS receiver fair value as total-return leg minus accrued financing
- Add ACT/365 financing accrual using reference rate plus spread bps and reset dates
- Add mark-to-market output for total return leg, financing leg, net MTM, and accrued days
- Add tests covering known swap economics, negative receiver value, reference-rate overrides, and invalid inputs

Refs #45

## Validation
- `pytest tests/test_total_return_swap.py`
- `pytest`
- `git diff --check`
