### PR TITLE
Add futures pricing integration example

### DIFF
--- a/beacon/derivatives/__init__.py
+++ b/beacon/derivatives/__init__.py
@@ -1,0 +1,6 @@
+"""Derivative instruments and pricing helpers."""
+
+from .futures import IndexFuture
+from .pricing import cost_of_carry_fair_value, implied_repo_rate
+
+__all__ = ["IndexFuture", "cost_of_carry_fair_value", "implied_repo_rate"]

--- a/beacon/derivatives/futures.py
+++ b/beacon/derivatives/futures.py
@@ -1,0 +1,98 @@
+"""Futures contract models."""
+from __future__ import annotations
+
+import math
+from typing import Dict
+
+import pandas as pd
+
+from .pricing import cost_of_carry_fair_value
+
+
+class IndexFuture:
+    """Index futures contract with cost-of-carry pricing and basis analytics."""
+
+    def __init__(
+        self,
+        derivative_id: str,
+        underlying_id: str,
+        currency: str,
+        expiry_date: str,
+        contract_multiplier: float,
+        tick_size: float,
+        tick_value: float,
+    ):
+        if not derivative_id:
+            raise ValueError("derivative_id cannot be empty.")
+        if not underlying_id:
+            raise ValueError("underlying_id cannot be empty.")
+        if not currency:
+            raise ValueError("currency cannot be empty.")
+        if contract_multiplier <= 0:
+            raise ValueError("contract_multiplier must be positive.")
+        if tick_size <= 0:
+            raise ValueError("tick_size must be positive.")
+        if tick_value <= 0:
+            raise ValueError("tick_value must be positive.")
+
+        self.derivative_id = derivative_id
+        self.underlying_id = underlying_id
+        self.currency = currency
+        self.expiry_date = pd.Timestamp(expiry_date)
+        self.contract_multiplier = float(contract_multiplier)
+        self.tick_size = float(tick_size)
+        self.tick_value = float(tick_value)
+
+    def time_to_expiry(self, valuation_date: pd.Timestamp) -> float:
+        """Return ACT/365 years to expiry, floored at zero after expiry."""
+        return max((self.expiry_date - pd.Timestamp(valuation_date)).days, 0) / 365.0
+
+    def fair_value(
+        self,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        risk_free_rate: float,
+        dividend_yield: float = 0.0,
+        borrow_cost: float = 0.0,
+    ) -> float:
+        """Return cost-of-carry fair value for the contract."""
+        return cost_of_carry_fair_value(
+            spot=spot_price,
+            risk_free_rate=risk_free_rate,
+            dividend_yield=dividend_yield,
+            borrow_cost=borrow_cost,
+            time_to_expiry_years=self.time_to_expiry(valuation_date),
+        )
+
+    def basis(self, futures_price: float, spot_price: float) -> float:
+        """Return futures basis: futures price minus spot price."""
+        return futures_price - spot_price
+
+    def annualised_basis(self, futures_price: float, spot_price: float, valuation_date: pd.Timestamp) -> float:
+        """Return implied financing rate ln(F/S) / T."""
+        if futures_price <= 0:
+            raise ValueError("futures_price must be positive.")
+        if spot_price <= 0:
+            raise ValueError("spot_price must be positive.")
+        time_to_expiry = self.time_to_expiry(valuation_date)
+        if time_to_expiry == 0:
+            return 0.0
+        return math.log(futures_price / spot_price) / time_to_expiry
+
+    def mark_to_market(
+        self,
+        futures_price: float,
+        spot_price: float,
+        valuation_date: pd.Timestamp,
+        risk_free_rate: float,
+        dividend_yield: float = 0.0,
+        borrow_cost: float = 0.0,
+    ) -> Dict[str, float]:
+        """Return fair value, basis, theoretical edge, and time to expiry."""
+        fair_value = self.fair_value(spot_price, valuation_date, risk_free_rate, dividend_yield, borrow_cost)
+        return {
+            "fair_value": fair_value,
+            "basis": self.basis(futures_price, spot_price),
+            "theoretical_edge": futures_price - fair_value,
+            "time_to_expiry": self.time_to_expiry(valuation_date),
+        }

--- a/beacon/derivatives/pricing.py
+++ b/beacon/derivatives/pricing.py
@@ -1,0 +1,35 @@
+"""Pricing helpers for Delta-1 derivative instruments."""
+from __future__ import annotations
+
+import math
+
+
+def cost_of_carry_fair_value(
+    spot: float,
+    risk_free_rate: float,
+    dividend_yield: float,
+    time_to_expiry_years: float,
+    borrow_cost: float = 0.0,
+) -> float:
+    """Return futures fair value using F = S * exp((r - q + c) * T)."""
+    if spot <= 0:
+        raise ValueError("spot must be positive.")
+    if time_to_expiry_years < 0:
+        raise ValueError("time_to_expiry_years cannot be negative.")
+    return spot * math.exp((risk_free_rate - dividend_yield + borrow_cost) * time_to_expiry_years)
+
+
+def implied_repo_rate(
+    futures_price: float,
+    spot: float,
+    dividend_yield: float,
+    time_to_expiry_years: float,
+) -> float:
+    """Return implied repo/risk-free rate from a futures price."""
+    if futures_price <= 0:
+        raise ValueError("futures_price must be positive.")
+    if spot <= 0:
+        raise ValueError("spot must be positive.")
+    if time_to_expiry_years <= 0:
+        raise ValueError("time_to_expiry_years must be positive.")
+    return (math.log(futures_price / spot) + dividend_yield * time_to_expiry_years) / time_to_expiry_years

--- a/examples/futures_pricing_example.py
+++ b/examples/futures_pricing_example.py
@@ -1,0 +1,92 @@
+"""Price an IndexFuture using spot levels from an IndexResult.
+
+This example is intentionally synthetic so it can run without external data.
+It demonstrates the integration path:
+
+    IndexResult -> latest index level as spot -> IndexFuture fair value
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from beacon.derivatives import IndexFuture, implied_repo_rate
+from beacon.index.result import IndexResult
+
+
+def build_synthetic_index_result() -> IndexResult:
+    """Create a small pre-built IndexResult with synthetic index levels."""
+    dates = pd.bdate_range("2025-01-02", periods=5)
+    index_levels = pd.Series([100.0, 101.2, 100.8, 102.4, 103.0], index=dates)
+    divisor_history = pd.Series(1.0, index=dates)
+    weights = {dates[0]: {"AAA": 0.6, "BBB": 0.4}}
+    constituents = {dates[0]: ["AAA", "BBB"]}
+
+    return IndexResult(
+        index_id="synthetic_two_asset_index",
+        index_levels=index_levels,
+        divisor_history=divisor_history,
+        constituent_snapshots=constituents,
+        weight_snapshots=weights,
+    )
+
+
+def main() -> None:
+    """Run the end-to-end synthetic futures pricing example."""
+    # 1. Create or load an IndexResult. A production workflow would usually
+    #    produce this from IndexCalculator; this example keeps the data inline.
+    index_result = build_synthetic_index_result()
+
+    # 2. Use the latest index level as the spot price for the futures contract.
+    valuation_date = index_result.index_levels.index[-1]
+    spot_price = float(index_result.index_levels.iloc[-1])
+
+    # 3. Price an IndexFuture with cost-of-carry assumptions.
+    risk_free_rate = 0.045
+    dividend_yield = 0.015
+    borrow_cost = 0.002
+    future = IndexFuture(
+        derivative_id="SYN-FUT-2026",
+        underlying_id=index_result.index_id,
+        currency="USD",
+        expiry_date="2026-01-02",
+        contract_multiplier=50.0,
+        tick_size=0.25,
+        tick_value=12.5,
+    )
+    fair_value = future.fair_value(
+        spot_price=spot_price,
+        valuation_date=valuation_date,
+        risk_free_rate=risk_free_rate,
+        dividend_yield=dividend_yield,
+        borrow_cost=borrow_cost,
+    )
+
+    # 4. Compare a synthetic market futures price to fair value.
+    market_futures_price = fair_value + 0.75
+    basis = future.basis(market_futures_price, spot_price)
+    repo = implied_repo_rate(
+        futures_price=market_futures_price,
+        spot=spot_price,
+        dividend_yield=dividend_yield,
+        time_to_expiry_years=future.time_to_expiry(valuation_date),
+    )
+
+    # 5. Print a compact summary table for docs/tutorial usage.
+    summary = pd.DataFrame(
+        [
+            ("valuation_date", valuation_date.date().isoformat()),
+            ("index_id", index_result.index_id),
+            ("spot_level", f"{spot_price:.4f}"),
+            ("future_fair_value", f"{fair_value:.4f}"),
+            ("market_futures_price", f"{market_futures_price:.4f}"),
+            ("basis", f"{basis:.4f}"),
+            ("implied_repo_rate", f"{repo:.4%}"),
+        ],
+        columns=["metric", "value"],
+    )
+    print(summary.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `examples/futures_pricing_example.py` showing IndexResult -> IndexFuture pricing integration with synthetic data
- Use the latest index level as spot, price with cost-of-carry assumptions, calculate basis, and calculate implied repo rate
- Print a compact summary table for documentation/tutorial usage
- Include minimal derivatives exports used by the example

Refs #46

## Validation
- `PYTHONPATH=. python examples/futures_pricing_example.py`
- `pytest`
- `git diff --check`
