### PR TITLE
Standardise logging verbosity

### DIFF
--- a/beacon/backtest/engine.py
+++ b/beacon/backtest/engine.py
@@ -245,13 +245,11 @@ class BacktestEngine:
             if trade.side == "SELL":
                 portfolio.execute_sell(trade.asset_id, trade.quantity, trade.price,
                                       cost=trade.cost, date=date)
-                logger.debug(f"[{date}] Sold {trade.quantity:.4f} of {trade.asset_id}")
             elif trade.side == "BUY":
                 total_needed = trade.quantity * trade.price + trade.cost
                 if portfolio.cash_balance >= total_needed:
                     portfolio.execute_buy(trade.asset_id, trade.quantity, trade.price,
                                           cost=trade.cost, date=date)
-                    logger.debug(f"[{date}] Bought {trade.quantity:.4f} of {trade.asset_id}")
                 else:
                     logger.warning(
                         f"[{date}] Insufficient cash for {trade.asset_id}. "

--- a/beacon/backtest/rules.py
+++ b/beacon/backtest/rules.py
@@ -98,14 +98,7 @@ class DriftThresholdModifier(BacktestModifier):
             if drift > max_drift:
                 max_drift = drift
 
-        skip = max_drift <= self.threshold
-        if skip:
-            import logging
-            logging.getLogger(__name__).debug(
-                f"[{date}] Max drift {max_drift:.4f} <= threshold "
-                f"{self.threshold:.4f}. Skipping rebalance."
-            )
-        return skip
+        return max_drift <= self.threshold
 
     def adjust_trades(self,
                       trades: List['TradeInstruction'],

--- a/beacon/fund/base.py
+++ b/beacon/fund/base.py
@@ -106,7 +106,6 @@ class IndexFund:
             current_date=current_date
         )
 
-        logger.debug(f"Target weights for '{self.fund_id}': {{asset.asset_id: w for asset, w in self._target_weights.items()}}")
 
         # Build target weights keyed by asset_id string
         target_weights_by_id: Dict[str, float] = {
@@ -138,7 +137,6 @@ class IndexFund:
 
                 if quantity_to_sell > 1e-6:
                     self.portfolio.execute_sell(asset_id, quantity_to_sell, current_price, date=current_date)
-                    logger.debug(f"Fund rebalance: Sold {quantity_to_sell:.2f} of {asset_id}")
 
         # Buy assets in target or underweights
         for asset_id, target_weight in target_weights_by_id.items():
@@ -159,7 +157,6 @@ class IndexFund:
                 quantity_to_buy = value_to_buy / current_price
                 if self.portfolio.cash_balance >= value_to_buy:
                     self.portfolio.execute_buy(asset_id, quantity_to_buy, current_price, date=current_date)
-                    logger.debug(f"Fund rebalance: Bought {quantity_to_buy:.2f} of {asset_id}")
                 else:
                     logger.warning(f"Fund rebalance: Insufficient cash to buy {asset_id} for fund '{self.fund_id}'.")
 
@@ -184,7 +181,6 @@ class IndexFund:
             fee_amount = nav * daily_fee_rate
             # NAV before daily fee deduction (placeholder for more sophisticated fee model)
 
-        logger.debug(f"Calculated NAV for fund '{self.fund_id}' on {current_date.strftime('%Y-%m-%d')}: {nav:.2f}")
         return nav
 
     def __repr__(self) -> str:

--- a/beacon/fund/etf.py
+++ b/beacon/fund/etf.py
@@ -85,8 +85,6 @@ class ETF(IndexFund):
 
         # Simplistic simulation: market price = NAV (perfect tracking for now)
         self.market_price = nav_per_share
-        logger.debug(f"Simulated market price for ETF '{self.etf_ticker}' on "
-                     f"{current_date.strftime('%Y-%m-%d')}: {self.market_price:.2f} (based on NAV)")
         # Add more complex logic here later, e.g., premium/discount simulation
         return self.market_price
 

--- a/beacon/index/calculation.py
+++ b/beacon/index/calculation.py
@@ -118,7 +118,6 @@ class IndexCalculator:
                 try:
                     if not rule.is_eligible(asset, current_date, self.data):
                         is_eligible_for_asset = False
-                        logger.debug(f"Asset {asset.asset_id} failed eligibility rule: {rule.rule_name}")
                         break
                 except Exception as e:
                     logger.error(f"Error applying eligibility rule {rule.rule_name} to asset {asset.asset_id}: {e}")
@@ -127,7 +126,6 @@ class IndexCalculator:
 
             if is_eligible_for_asset:
                 eligible_constituents.append(asset)
-                logger.debug(f"Asset {asset.asset_id} passed all eligibility rules.")
 
         logger.info(f"Selected {len(eligible_constituents)} constituents for '{self.definition.index_name}'.")
         return eligible_constituents
@@ -343,9 +341,6 @@ class IndexCalculator:
 
         new_index_level = current_total_adjusted_market_value / divisor
 
-        logger.debug(f"[{current_date.strftime('%Y-%m-%d')}] Index '{self.definition.index_name}': "
-                     f"Total Market Value = {current_total_adjusted_market_value:.2f}, Divisor = {divisor:.4f}, "
-                     f"New Level = {new_index_level:.4f}")
         return new_index_level, divisor
 
 
@@ -460,13 +455,7 @@ class IndexCalculator:
                     return current_divisor_before_ca
 
             reduction_index_ccy = reduction_local * fx_rate
-            logger.debug(
-                f"Special Dividend: Asset {asset_involved.asset_id}, "
-                f"reduction value (index ccy): {reduction_index_ccy:.2f}"
-            )
-
             if abs(reduction_index_ccy) < 1e-9:
-                logger.debug("Reduction is negligible. Divisor not changed.")
                 return current_divisor_before_ca
 
             if current_total_market_value_before_ca <= 0:
@@ -687,8 +676,6 @@ class IndexCalculator:
         Returns:
             Tuple of (new_index_level, new_divisor).
         """
-        logger.debug(f"--- Daily Calculation for {self.definition.index_name} on {current_date.strftime('%Y-%m-%d')} ---")
-
         divisor = previous_divisor
 
         if divisor is None or divisor <= 0:
@@ -715,5 +702,4 @@ class IndexCalculator:
             previous_index_level=previous_index_level,
         )
 
-        logger.debug(f"--- End Daily Calculation for {self.definition.index_name} on {current_date.strftime('%Y-%m-%d')} --- Level: {new_level:.4f}")
         return new_level, final_divisor

--- a/beacon/index/methodology.py
+++ b/beacon/index/methodology.py
@@ -70,7 +70,6 @@ class MarketCapRule(EligibilityRuleBase):
         # This logic is simplified. Real market cap data might be directly available or need careful calculation.
         from ..asset.equity import Equity # Specific check for equity attributes
         if not isinstance(asset, Equity):
-            logger.debug(f"MarketCapRule: Asset {asset.asset_id} is not Equity type, skipping.")
             return True # Or False, depending on how non-equities should be handled by this rule
 
         try:
@@ -88,12 +87,9 @@ class MarketCapRule(EligibilityRuleBase):
             market_cap = current_price * shares_outstanding
 
             if self.min_market_cap is not None and market_cap < self.min_market_cap:
-                logger.debug(f"MarketCapRule: {asset.ticker} (MCap: {market_cap:.2f}) below min_market_cap {self.min_market_cap:.2f}")
                 return False
             if self.max_market_cap is not None and market_cap > self.max_market_cap:
-                logger.debug(f"MarketCapRule: {asset.ticker} (MCap: {market_cap:.2f}) above max_market_cap {self.max_market_cap:.2f}")
                 return False
-            logger.debug(f"MarketCapRule: {asset.ticker} (MCap: {market_cap:.2f}) is eligible.")
             return True
         except Exception as e:
             logger.error(f"MarketCapRule: Error checking eligibility for {asset.ticker}: {e}")
@@ -139,7 +135,6 @@ class LiquidityRule(EligibilityRuleBase):
                     return False
                 avg_daily_volume = price_df['Volume'].mean()
                 if avg_daily_volume < self.min_avg_daily_volume:
-                    logger.debug(f"LiquidityRule: {asset.ticker} (ADV: {avg_daily_volume:.0f}) below min volume {self.min_avg_daily_volume:.0f}")
                     return False
 
             if self.min_avg_daily_value is not None:
@@ -149,10 +144,8 @@ class LiquidityRule(EligibilityRuleBase):
                     return False
                 avg_daily_value = (price_df['Adj Close'] * price_df['Volume']).mean()
                 if avg_daily_value < self.min_avg_daily_value:
-                    logger.debug(f"LiquidityRule: {asset.ticker} (ADTV: {avg_daily_value:.2f}) below min value {self.min_avg_daily_value:.2f}")
                     return False
             
-            logger.debug(f"LiquidityRule: {asset.ticker} is eligible.")
             return True
         except Exception as e:
             logger.error(f"LiquidityRule: Error checking eligibility for {asset.ticker}: {e}")

--- a/beacon/portfolio/base.py
+++ b/beacon/portfolio/base.py
@@ -66,7 +66,6 @@ class Holding:
             return
         self.current_price = current_price
         self.market_value = self.quantity * self.current_price
-        logger.debug(f"Holding for {self.asset_id} updated: Qty={self.quantity}, Price={self.current_price}, MV={self.market_value}")
 
 
 class Portfolio:
@@ -138,7 +137,7 @@ class Portfolio:
                 asset_id=asset_id, quantity=quantity, average_cost_price=price
             )
 
-        logger.info(f"BUY: {quantity} of {asset_id} @ {price:.2f}. Cash: {self.cash_balance:.2f}")
+        logger.debug(f"BUY: {quantity} of {asset_id} @ {price:.2f}. Cash: {self.cash_balance:.2f}")
 
         self.transactions.append(
             Transaction(asset_id, quantity, price, 'BUY', tx_date, cost)
@@ -180,10 +179,10 @@ class Portfolio:
         self.cash_balance += (trade_value - cost)
 
         self.holdings[asset_id].quantity -= quantity
-        logger.info(f"SELL: {quantity} of {asset_id} @ {price:.2f}. Cash: {self.cash_balance:.2f}")
+        logger.debug(f"SELL: {quantity} of {asset_id} @ {price:.2f}. Cash: {self.cash_balance:.2f}")
 
         if self.holdings[asset_id].quantity < 1e-9:
-            logger.info(f"Fully sold asset: {asset_id}. Removing from holdings.")
+            logger.debug(f"Fully sold asset: {asset_id}. Removing from holdings.")
             del self.holdings[asset_id]
 
         self.transactions.append(
@@ -229,8 +228,6 @@ class Portfolio:
                                "It will not be included in total portfolio value calculation based on market prices.")
 
         total_portfolio_value = total_holdings_value + self.cash_balance
-        logger.debug(f"Total portfolio value for '{self.portfolio_id}': "
-                     f"{total_portfolio_value:.2f} (Holdings: {total_holdings_value:.2f}, Cash: {self.cash_balance:.2f})")
         return total_portfolio_value
 
     def get_weights(self) -> Dict[str, float]:


### PR DESCRIPTION
## Summary
- Remove noisy debug logs from per-asset/per-day index calculation, eligibility, liquidity, NAV, and rebalance hot paths
- Keep missing data and fallback behavior at warning/error levels where they affect results
- Downgrade individual portfolio trade execution messages from info to debug so info remains reserved for higher-level lifecycle/rebalance events
- Simplify drift-threshold rebalance skipping without emitting per-date debug lines

Refs #49

## Validation
- `pytest`
- `git diff --check`
