### PR TITLE
Remove circular import type workarounds

### DIFF
--- a/beacon/asset/view.py
+++ b/beacon/asset/view.py
@@ -3,11 +3,12 @@
 AssetView — convenience wrapper combining an asset identifier with a DataFetcher
 for streamlined data retrieval.
 """
-import pandas as pd
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
 
-if TYPE_CHECKING:
-    from ..data.fetcher import DataFetcher
+import pandas as pd
+from typing import Optional
+
+from ..data.fetcher import DataFetcher
 
 
 class AssetView:
@@ -21,7 +22,7 @@ class AssetView:
         The data provider instance.
     """
 
-    def __init__(self, asset_id: str, data_fetcher: 'DataFetcher'):
+    def __init__(self, asset_id: str, data_fetcher: DataFetcher):
         if not asset_id:
             raise ValueError("asset_id cannot be empty.")
         if data_fetcher is None:

--- a/beacon/backtest/asset_view.py
+++ b/beacon/backtest/asset_view.py
@@ -3,14 +3,14 @@
 BacktestAssetView — asset view extended with backtest-specific context
 such as actual weight history, holding periods, and transaction analysis.
 """
+from __future__ import annotations
+
 import pandas as pd
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, Optional
 
 from ..asset.view import AssetView
-
-if TYPE_CHECKING:
-    from ..data.fetcher import DataFetcher
-    from ..portfolio.base import Transaction
+from ..data.fetcher import DataFetcher
+from ..portfolio.base import Transaction
 
 
 class BacktestAssetView(AssetView):
@@ -35,10 +35,10 @@ class BacktestAssetView(AssetView):
 
     def __init__(self,
                  asset_id: str,
-                 data_fetcher: 'DataFetcher',
+                 data_fetcher: DataFetcher,
                  actual_weight_history: pd.DataFrame,
                  portfolio_nav: pd.Series,
-                 transactions: List['Transaction'],
+                 transactions: List[Transaction],
                  target_weight_snapshots: Optional[Dict[pd.Timestamp, Dict[str, float]]] = None):
         super().__init__(asset_id, data_fetcher)
         self._actual_weight_history = actual_weight_history

--- a/beacon/backtest/engine.py
+++ b/beacon/backtest/engine.py
@@ -2,18 +2,18 @@
 """
 BacktestEngine — simulates portfolio execution against a target weight schedule.
 """
+from __future__ import annotations
+
 import pandas as pd
 import logging
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, Optional
 from dataclasses import dataclass
 
-if TYPE_CHECKING:
-    from ..data.fetcher import DataFetcher
-    from ..index.result import IndexResult
-    from .rules import BacktestModifier
-
+from ..data.fetcher import DataFetcher
+from ..index.result import IndexResult
 from ..portfolio.base import Portfolio
 from .result import BacktestResult
+from .rules import BacktestModifier
 
 logger = logging.getLogger(__name__)
 
@@ -80,12 +80,12 @@ class BacktestEngine:
                  start_date: str,
                  end_date: str,
                  initial_capital: float,
-                 data_provider: 'DataFetcher',
-                 target_index_result: Optional['IndexResult'] = None,
+                 data_provider: DataFetcher,
+                 target_index_result: Optional[IndexResult] = None,
                  target_weights: Optional[Dict[pd.Timestamp, Dict[str, float]]] = None,
                  price_column: str = "CLOSE",
                  transaction_cost_bps: float = 0.0,
-                 modifiers: Optional[List['BacktestModifier']] = None):
+                 modifiers: Optional[List[BacktestModifier]] = None):
         if target_index_result is not None and target_weights is not None:
             raise ValueError(
                 "Provide either target_index_result or target_weights, not both."
@@ -98,12 +98,12 @@ class BacktestEngine:
         self.start_date: pd.Timestamp = pd.Timestamp(start_date)
         self.end_date: pd.Timestamp = pd.Timestamp(end_date)
         self.initial_capital: float = initial_capital
-        self.data_provider: 'DataFetcher' = data_provider
-        self.target_index_result: Optional['IndexResult'] = target_index_result
+        self.data_provider: DataFetcher = data_provider
+        self.target_index_result: Optional[IndexResult] = target_index_result
         self.price_column: str = price_column
 
         self.transaction_cost_bps: float = transaction_cost_bps
-        self.modifiers: List['BacktestModifier'] = modifiers or []
+        self.modifiers: List[BacktestModifier] = modifiers or []
 
         # Normalise weight schedule to a dict
         if target_weights is not None:

--- a/beacon/backtest/result.py
+++ b/beacon/backtest/result.py
@@ -2,16 +2,17 @@
 """
 BacktestResult — output container for backtest runs.
 """
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, Optional
 
-if TYPE_CHECKING:
-    from ..data.fetcher import DataFetcher
-    from ..index.result import IndexResult
-    from ..portfolio.base import Transaction
-    from .asset_view import BacktestAssetView
+from ..data.fetcher import DataFetcher
+from ..index.result import IndexResult
+from ..portfolio.base import Transaction
+from .asset_view import BacktestAssetView
 
 
 @dataclass
@@ -39,17 +40,17 @@ class BacktestResult:
     initial_capital: float
     portfolio_nav: pd.Series
     cash_history: pd.Series
-    transactions: List['Transaction']
+    transactions: List[Transaction]
     actual_weight_history: pd.DataFrame
-    target_index_result: Optional['IndexResult'] = None
-    _data_fetcher: Optional['DataFetcher'] = field(default=None, repr=False, compare=False)
+    target_index_result: Optional[IndexResult] = None
+    _data_fetcher: Optional[DataFetcher] = field(default=None, repr=False, compare=False)
 
-    def with_data(self, data_fetcher: 'DataFetcher') -> 'BacktestResult':
+    def with_data(self, data_fetcher: DataFetcher) -> BacktestResult:
         """Bind a DataFetcher for asset-level queries. Returns self for chaining."""
         self._data_fetcher = data_fetcher
         return self
 
-    def asset(self, asset_id: str) -> 'BacktestAssetView':
+    def asset(self, asset_id: str) -> BacktestAssetView:
         """Return a BacktestAssetView for a held asset.
 
         Parameters

--- a/beacon/backtest/rules.py
+++ b/beacon/backtest/rules.py
@@ -2,14 +2,14 @@
 """
 BacktestModifier — optional hooks that alter rebalance behaviour.
 """
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Dict, List, TYPE_CHECKING
+from typing import Dict, List
 
 import pandas as pd
 
-if TYPE_CHECKING:
-    from ..portfolio.base import Portfolio
-    from .engine import TradeInstruction
+from ..portfolio.base import Portfolio
 
 
 class BacktestModifier(ABC):
@@ -22,7 +22,7 @@ class BacktestModifier(ABC):
     @abstractmethod
     def should_skip_rebalance(self,
                               date: pd.Timestamp,
-                              portfolio: 'Portfolio',
+                              portfolio: Portfolio,
                               target_weights: Dict[str, float]) -> bool:
         """Return ``True`` to skip the scheduled rebalance on *date*.
 
@@ -42,9 +42,9 @@ class BacktestModifier(ABC):
 
     @abstractmethod
     def adjust_trades(self,
-                      trades: List['TradeInstruction'],
+                      trades: List[TradeInstruction],
                       date: pd.Timestamp,
-                      portfolio: 'Portfolio') -> List['TradeInstruction']:
+                      portfolio: Portfolio) -> List[TradeInstruction]:
         """Optionally modify the trade list before execution.
 
         Parameters
@@ -81,7 +81,7 @@ class DriftThresholdModifier(BacktestModifier):
 
     def should_skip_rebalance(self,
                               date: pd.Timestamp,
-                              portfolio: 'Portfolio',
+                              portfolio: Portfolio,
                               target_weights: Dict[str, float]) -> bool:
         current_weights = portfolio.get_weights()
 
@@ -108,8 +108,8 @@ class DriftThresholdModifier(BacktestModifier):
         return skip
 
     def adjust_trades(self,
-                      trades: List['TradeInstruction'],
+                      trades: List[TradeInstruction],
                       date: pd.Timestamp,
-                      portfolio: 'Portfolio') -> List['TradeInstruction']:
+                      portfolio: Portfolio) -> List[TradeInstruction]:
         """Pass-through — no trade adjustment."""
         return trades

--- a/beacon/fund/base.py
+++ b/beacon/fund/base.py
@@ -2,16 +2,17 @@
 """
 Module defining the IndexFund class.
 """
+from __future__ import annotations
+
 import pandas as pd
-from typing import Dict, Any, TYPE_CHECKING
+from typing import Dict, Any
 import logging
 
-# Avoid circular imports for type hinting
-if TYPE_CHECKING:
-    from ..index.constructor import IndexDefinition
-    from ..portfolio.base import Portfolio
-    from ..data.fetcher import DataFetcher
-    from ..index.calculation import IndexCalculator
+from ..index.constructor import IndexDefinition
+from ..portfolio.base import Portfolio
+from ..data.fetcher import DataFetcher
+from ..index.calculation import IndexCalculator
+from ..asset.base import Asset
 
 
 logger = logging.getLogger(__name__)
@@ -22,10 +23,10 @@ class IndexFund:
     """
     def __init__(self,
                  fund_id: str,
-                 target_index_definition: 'IndexDefinition', # The static definition
-                 index_agent: 'IndexCalculator', # The agent to calculate weights for target_index
-                 portfolio: 'Portfolio',
-                 data_provider: 'DataFetcher',
+                 target_index_definition: IndexDefinition, # The static definition
+                 index_agent: IndexCalculator, # The agent to calculate weights for target_index
+                 portfolio: Portfolio,
+                 data_provider: DataFetcher,
                  management_fee_bps: int = 0):
         """
         Initializes an IndexFund.
@@ -53,14 +54,14 @@ class IndexFund:
             raise ValueError("management_fee_bps cannot be negative.")
 
         self.fund_id: str = fund_id
-        self.target_index_definition: 'IndexDefinition' = target_index_definition
-        self.index_agent: 'IndexCalculator' = index_agent
-        self.portfolio: 'Portfolio' = portfolio
-        self.data_provider: 'DataFetcher' = data_provider
+        self.target_index_definition: IndexDefinition = target_index_definition
+        self.index_agent: IndexCalculator = index_agent
+        self.portfolio: Portfolio = portfolio
+        self.data_provider: DataFetcher = data_provider
         self.management_fee_bps: int = management_fee_bps # e.g., 20 for 0.20%
 
         # Store target weights, to be updated upon rebalance_to_index
-        self._target_weights: Dict['Asset', float] = {}
+        self._target_weights: Dict[Asset, float] = {}
 
 
     def _fetch_price(self, ticker: str, current_date: pd.Timestamp) -> float | None:

--- a/beacon/fund/etf.py
+++ b/beacon/fund/etf.py
@@ -2,19 +2,18 @@
 """
 Module defining the ETF (Exchange Traded Fund) class, inheriting from IndexFund.
 """
+from __future__ import annotations
+
 import pandas as pd
-from typing import Dict, Any, Optional, TYPE_CHECKING
+from typing import Dict, Any, Optional
 
 from .base import IndexFund
+from ..index.constructor import IndexDefinition
+from ..portfolio.base import Portfolio
+from ..analysis.etf.analytics import ETFAnalytics
+from ..data.fetcher import DataFetcher
+from ..index.calculation import IndexCalculator
 import logging
-
-# Avoid circular imports for type hinting
-if TYPE_CHECKING:
-    from ..index.constructor import IndexDefinition
-    from ..portfolio.base import Portfolio
-    from ..analysis.etf.analytics import ETFAnalytics # For type hint
-    from ..data.fetcher import DataFetcher
-    from ..index.calculation import IndexCalculator
 
 
 logger = logging.getLogger(__name__)
@@ -27,10 +26,10 @@ class ETF(IndexFund):
     def __init__(self,
                  fund_id: str,
                  etf_ticker: str,
-                 target_index_definition: 'IndexDefinition',
-                 index_agent: 'IndexCalculator',
-                 portfolio: 'Portfolio',
-                 data_provider: 'DataFetcher',
+                 target_index_definition: IndexDefinition,
+                 index_agent: IndexCalculator,
+                 portfolio: Portfolio,
+                 data_provider: DataFetcher,
                  management_fee_bps: int = 0,
                  creation_unit_size: int = 50000): # Typical size of a creation unit
         """
@@ -95,7 +94,7 @@ class ETF(IndexFund):
                                  start_date: str,
                                  end_date: str,
                                  # benchmark_returns: pd.Series, # Index returns should be fetched or calculated
-                                 analysis_module: 'ETFAnalytics') -> Dict[str, float]:
+                                 analysis_module: ETFAnalytics) -> Dict[str, float]:
         """
         Calculates tracking performance metrics (e.g., tracking error, tracking difference)
         against its benchmark index.

--- a/beacon/index/asset_view.py
+++ b/beacon/index/asset_view.py
@@ -3,13 +3,13 @@
 IndexAssetView — asset view extended with index-specific context
 such as weight history and contribution analysis.
 """
+from __future__ import annotations
+
 import pandas as pd
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import Dict, Optional
 
 from ..asset.view import AssetView
-
-if TYPE_CHECKING:
-    from ..data.fetcher import DataFetcher
+from ..data.fetcher import DataFetcher
 
 
 class IndexAssetView(AssetView):
@@ -30,7 +30,7 @@ class IndexAssetView(AssetView):
 
     def __init__(self,
                  asset_id: str,
-                 data_fetcher: 'DataFetcher',
+                 data_fetcher: DataFetcher,
                  weight_snapshots: Dict[pd.Timestamp, Dict[str, float]],
                  index_levels: pd.Series):
         super().__init__(asset_id, data_fetcher)

--- a/beacon/index/calculation.py
+++ b/beacon/index/calculation.py
@@ -3,17 +3,17 @@
 Module for the IndexCalculator, responsible for the logic of
 constituent selection, weighting, index level calculation, and corporate action adjustments.
 """
+from __future__ import annotations
+
 import pandas as pd
 import numpy as np
-from typing import List, Dict, Tuple, Optional, Any, TYPE_CHECKING
+from typing import List, Dict, Tuple, Optional, Any
 import logging
 
-# Avoid circular imports for type hinting
-if TYPE_CHECKING:
-    from .constructor import IndexDefinition
-    from ..asset.base import Asset
-    from ..data.fetcher import DataFetcher
-    from ..exceptions import CalculationError
+from .constructor import IndexDefinition
+from ..asset.base import Asset
+from ..data.fetcher import DataFetcher
+from ..exceptions import CalculationError
 
 logger = logging.getLogger(__name__)
 
@@ -25,8 +25,8 @@ class IndexCalculator:
     through method parameters and return values.
     """
     def __init__(self,
-                 index_definition: 'IndexDefinition',
-                 data_provider: 'DataFetcher'):
+                 index_definition: IndexDefinition,
+                 data_provider: DataFetcher):
         """
         Initializes the IndexCalculator.
 
@@ -39,13 +39,13 @@ class IndexCalculator:
         if not data_provider:
             raise ValueError("data_provider must be provided.")
 
-        self.definition: 'IndexDefinition' = index_definition
-        self.data: 'DataFetcher' = data_provider
+        self.definition: IndexDefinition = index_definition
+        self.data: DataFetcher = data_provider
 
         logger.info(f"IndexCalculator initialized for index '{self.definition.index_name}'.")
 
 
-    def _get_universe(self, date: pd.Timestamp) -> List['Asset']:
+    def _get_universe(self, date: pd.Timestamp) -> List[Asset]:
         """Resolve universe_identifiers from the IndexDefinition into Asset objects.
 
         Uses ``self.data.fetch_reference_data`` to look up metadata for each
@@ -68,7 +68,7 @@ class IndexCalculator:
             )
             return []
 
-        assets: List['Asset'] = []
+        assets: List[Asset] = []
         date_str = date.strftime('%Y-%m-%d')
 
         for identifier in identifiers:
@@ -95,7 +95,7 @@ class IndexCalculator:
         )
         return assets
 
-    def select_constituents(self, universe: List['Asset'], current_date: pd.Timestamp) -> List['Asset']:
+    def select_constituents(self, universe: List[Asset], current_date: pd.Timestamp) -> List[Asset]:
         """
         Selects index constituents from a given universe based on eligibility rules.
 
@@ -107,7 +107,7 @@ class IndexCalculator:
             A list of Asset objects that are eligible for the index.
         """
         logger.info(f"[{current_date.strftime('%Y-%m-%d')}] Selecting constituents for '{self.definition.index_name}'. Universe size: {len(universe)}")
-        eligible_constituents: List['Asset'] = []
+        eligible_constituents: List[Asset] = []
         if not universe:
             logger.warning("Constituent selection called with an empty universe.")
             return []
@@ -132,7 +132,7 @@ class IndexCalculator:
         logger.info(f"Selected {len(eligible_constituents)} constituents for '{self.definition.index_name}'.")
         return eligible_constituents
 
-    def calculate_constituent_weights(self, constituents: List['Asset'], current_date: pd.Timestamp) -> Dict['Asset', float]:
+    def calculate_constituent_weights(self, constituents: List[Asset], current_date: pd.Timestamp) -> Dict[Asset, float]:
         """
         Calculates the weights for the given constituents based on the index's weighting scheme.
 
@@ -237,8 +237,8 @@ class IndexCalculator:
         return new_divisor
 
     def _get_constituent_market_values(self,
-                                       constituents_with_weights: Dict['Asset', float],
-                                       current_date: pd.Timestamp) -> Dict['Asset', float]:
+                                       constituents_with_weights: Dict[Asset, float],
+                                       current_date: pd.Timestamp) -> Dict[Asset, float]:
         """
         Helper to get current market values for constituents.
         Market Value = Price * Shares * FX_Rate_to_Index_Currency * (FreeFloat if applicable)
@@ -248,7 +248,7 @@ class IndexCalculator:
         """
         from ..asset.equity import Equity # Specific check for equity attributes
 
-        constituent_market_values: Dict['Asset', float] = {}
+        constituent_market_values: Dict[Asset, float] = {}
 
         for asset, weight in constituents_with_weights.items():
             if not isinstance(asset, Equity):
@@ -303,8 +303,8 @@ class IndexCalculator:
 
     def calculate_index_level(self,
                               current_date: pd.Timestamp,
-                              constituents: List['Asset'],
-                              weights: Dict['Asset', float],
+                              constituents: List[Asset],
+                              weights: Dict[Asset, float],
                               divisor: float,
                               previous_index_level: float
                              ) -> Tuple[float, float]:
@@ -354,7 +354,7 @@ class IndexCalculator:
 
     def handle_corporate_action(self,
                                 action: Dict[str, Any],
-                                constituents: List['Asset'],
+                                constituents: List[Asset],
                                 current_total_market_value_before_ca: float,
                                 current_divisor_before_ca: float
                                ) -> float:
@@ -506,7 +506,7 @@ class IndexCalculator:
     #todo: run() is currently iterating through all dates, this function should be vectorised for efficiency.
     def run(self,
             start_date: Optional[str] = None,
-            end_date: Optional[str] = None) -> 'IndexResult':
+            end_date: Optional[str] = None) -> IndexResult:
         """Run the full index calculation over a date range.
 
         Iterates through business days from *start_date* to *end_date*,
@@ -577,8 +577,8 @@ class IndexCalculator:
         weight_snapshots: Dict[pd.Timestamp, Dict[str, float]] = {}
 
         # Running state
-        constituents: List['Asset'] = []
-        weights: Dict['Asset', float] = {}
+        constituents: List[Asset] = []
+        weights: Dict[Asset, float] = {}
         divisor: float = 0.0
         level: float = self.definition.base_value
 
@@ -669,8 +669,8 @@ class IndexCalculator:
 
     def run_daily_calculation(self,
                               current_date: pd.Timestamp,
-                              constituents: List['Asset'],
-                              weights: Dict['Asset', float],
+                              constituents: List[Asset],
+                              weights: Dict[Asset, float],
                               previous_index_level: float,
                               previous_divisor: float
                              ) -> Tuple[float, float]:

--- a/beacon/index/constructor.py
+++ b/beacon/index/constructor.py
@@ -2,13 +2,13 @@
 """
 Module for defining the structure and rules of a financial index.
 """
+from __future__ import annotations
+
 import pandas as pd
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional
 import logging
 
-# Avoid circular imports for type hinting
-if TYPE_CHECKING:
-    from .methodology import EligibilityRuleBase, WeightingSchemeBase
+from .methodology import EligibilityRuleBase, WeightingSchemeBase
 
 
 logger = logging.getLogger(__name__)
@@ -23,8 +23,8 @@ class IndexDefinition:
                  base_date: str, # YYYY-MM-DD
                  base_value: float,
                  currency: str,
-                 eligibility_rules: List['EligibilityRuleBase'],
-                 weighting_scheme: 'WeightingSchemeBase',
+                 eligibility_rules: List[EligibilityRuleBase],
+                 weighting_scheme: WeightingSchemeBase,
                  rebalancing_frequency: str, # e.g., 'QUARTERLY', 'MONTHLY', 'SEMI-ANNUAL', 'ANNUAL'
                  description: Optional[str] = None,
                  universe_identifiers: Optional[List[str]] = None
@@ -66,8 +66,8 @@ class IndexDefinition:
         self.base_date: pd.Timestamp = pd.Timestamp(base_date)
         self.base_value: float = base_value
         self.currency: str = currency.upper()
-        self.eligibility_rules: List['EligibilityRuleBase'] = eligibility_rules
-        self.weighting_scheme: 'WeightingSchemeBase' = weighting_scheme
+        self.eligibility_rules: List[EligibilityRuleBase] = eligibility_rules
+        self.weighting_scheme: WeightingSchemeBase = weighting_scheme
         self.rebalancing_frequency: str = rebalancing_frequency.upper()
         self.description: Optional[str] = description
         self.universe_identifiers: Optional[List[str]] = universe_identifiers

--- a/beacon/index/methodology.py
+++ b/beacon/index/methodology.py
@@ -3,16 +3,16 @@
 Module defining base classes and examples for index methodology rules,
 such as eligibility criteria and weighting schemes.
 """
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 import pandas as pd
-from typing import List, Dict, Any, TYPE_CHECKING, Optional
+from typing import List, Dict, Any, Optional
 import logging
 
-# Avoid circular imports for type hinting
-if TYPE_CHECKING:
-    from ..asset.base import Asset
-    from ..asset.equity import Equity # For specific checks if needed
-    from ..data.fetcher import DataFetcher
+from ..asset.base import Asset
+from ..asset.equity import Equity
+from ..data.fetcher import DataFetcher
 
 
 logger = logging.getLogger(__name__)
@@ -27,9 +27,9 @@ class EligibilityRuleBase(ABC):
 
     @abstractmethod
     def is_eligible(self,
-                    asset: 'Asset',
+                    asset: Asset,
                     current_date: pd.Timestamp,
-                    market_data_provider: 'DataFetcher',
+                    market_data_provider: DataFetcher,
                     context: Optional[Dict[str, Any]] = None
                    ) -> bool:
         """
@@ -64,7 +64,7 @@ class MarketCapRule(EligibilityRuleBase):
         if min_market_cap is not None and max_market_cap is not None and min_market_cap > max_market_cap:
             raise ValueError("min_market_cap cannot be greater than max_market_cap.")
 
-    def is_eligible(self, asset: 'Asset', current_date: pd.Timestamp, market_data_provider: 'DataFetcher', context: Optional[Dict[str, Any]] = None) -> bool:
+    def is_eligible(self, asset: Asset, current_date: pd.Timestamp, market_data_provider: DataFetcher, context: Optional[Dict[str, Any]] = None) -> bool:
         # Requires fetching market cap data for the asset on current_date
         # Market Cap = Price * Shares Outstanding
         # This logic is simplified. Real market cap data might be directly available or need careful calculation.
@@ -112,7 +112,7 @@ class LiquidityRule(EligibilityRuleBase):
         if lookback_days <= 0:
             raise ValueError("lookback_days must be positive.")
 
-    def is_eligible(self, asset: 'Asset', current_date: pd.Timestamp, market_data_provider: 'DataFetcher', context: Optional[Dict[str, Any]] = None) -> bool:
+    def is_eligible(self, asset: Asset, current_date: pd.Timestamp, market_data_provider: DataFetcher, context: Optional[Dict[str, Any]] = None) -> bool:
         from ..asset.equity import Equity
         if not isinstance(asset, Equity):
             return True # Or False
@@ -173,11 +173,11 @@ class WeightingSchemeBase(ABC):
 
     @abstractmethod
     def calculate_weights(self,
-                          constituents: List['Asset'],
+                          constituents: List[Asset],
                           current_date: pd.Timestamp,
-                          market_data_provider: 'DataFetcher',
+                          market_data_provider: DataFetcher,
                           context: Optional[Dict[str, Any]] = None
-                         ) -> Dict['Asset', float]:
+                         ) -> Dict[Asset, float]:
         """
         Calculates the weight for each constituent asset.
 
@@ -208,9 +208,9 @@ class MarketCapWeighted(WeightingSchemeBase):
         super().__init__(scheme_name="MarketCapWeighted")
         self.use_free_float = use_free_float
 
-    def calculate_weights(self, constituents: List['Asset'], current_date: pd.Timestamp, market_data_provider: 'DataFetcher', context: Optional[Dict[str, Any]] = None) -> Dict['Asset', float]:
-        weights: Dict['Asset', float] = {}
-        market_caps: Dict['Asset', float] = {}
+    def calculate_weights(self, constituents: List[Asset], current_date: pd.Timestamp, market_data_provider: DataFetcher, context: Optional[Dict[str, Any]] = None) -> Dict[Asset, float]:
+        weights: Dict[Asset, float] = {}
+        market_caps: Dict[Asset, float] = {}
         total_market_cap = 0.0
 
         from ..asset.equity import Equity
@@ -271,8 +271,8 @@ class EqualWeighted(WeightingSchemeBase):
     def __init__(self):
         super().__init__(scheme_name="EqualWeighted")
 
-    def calculate_weights(self, constituents: List['Asset'], current_date: pd.Timestamp, market_data_provider: 'DataFetcher', context: Optional[Dict[str, Any]] = None) -> Dict['Asset', float]:
-        weights: Dict['Asset', float] = {}
+    def calculate_weights(self, constituents: List[Asset], current_date: pd.Timestamp, market_data_provider: DataFetcher, context: Optional[Dict[str, Any]] = None) -> Dict[Asset, float]:
+        weights: Dict[Asset, float] = {}
         num_constituents = len(constituents)
 
         if num_constituents > 0:

--- a/beacon/index/result.py
+++ b/beacon/index/result.py
@@ -2,14 +2,15 @@
 """
 IndexResult — output container for index calculation results.
 """
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, Optional
 
 import pandas as pd
 
-if TYPE_CHECKING:
-    from ..data.fetcher import DataFetcher
-    from .asset_view import IndexAssetView
+from ..data.fetcher import DataFetcher
+from .asset_view import IndexAssetView
 
 
 @dataclass
@@ -34,14 +35,14 @@ class IndexResult:
     divisor_history: pd.Series
     constituent_snapshots: Dict[pd.Timestamp, List[str]]
     weight_snapshots: Dict[pd.Timestamp, Dict[str, float]]
-    _data_fetcher: Optional['DataFetcher'] = field(default=None, repr=False, compare=False)
+    _data_fetcher: Optional[DataFetcher] = field(default=None, repr=False, compare=False)
 
-    def with_data(self, data_fetcher: 'DataFetcher') -> 'IndexResult':
+    def with_data(self, data_fetcher: DataFetcher) -> IndexResult:
         """Bind a DataFetcher for asset-level queries. Returns self for chaining."""
         self._data_fetcher = data_fetcher
         return self
 
-    def asset(self, asset_id: str) -> 'IndexAssetView':
+    def asset(self, asset_id: str) -> IndexAssetView:
         """Return an IndexAssetView for a constituent.
 
         Parameters

--- a/beacon/portfolio/reporting.py
+++ b/beacon/portfolio/reporting.py
@@ -3,8 +3,10 @@
 Module for generating reports from portfolio data, such as holdings reports
 and performance reports, potentially in formats like Excel.
 """
+from __future__ import annotations
+
 import pandas as pd
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 import logging
 
 # Try importing openpyxl for Excel writing
@@ -15,10 +17,8 @@ except ImportError:
     logging.warning("openpyxl library not found. Excel reporting will be disabled.")
     OPENPYXL_AVAILABLE = False
 
-# Avoid circular imports for type hinting
-if TYPE_CHECKING:
-    from .base import Portfolio
-    from ..data.fetcher import DataFetcher # For portfolio methods needing it
+from .base import Portfolio
+from ..data.fetcher import DataFetcher
 
 logger = logging.getLogger(__name__)
 
@@ -36,10 +36,10 @@ class ReportGenerator:
             logger.warning("ReportGenerator initialized, but openpyxl is missing. Excel output will fail.")
 
     def generate_holdings_report_excel(self,
-                                       portfolio: 'Portfolio',
+                                       portfolio: Portfolio,
                                        report_path: str,
                                        valuation_date: pd.Timestamp,
-                                       data_provider: 'DataFetcher') -> None:
+                                       data_provider: DataFetcher) -> None:
         """
         Generates an Excel report summarizing the current portfolio holdings.
 


### PR DESCRIPTION
## Summary
- Remove remaining `TYPE_CHECKING` import blocks from Beacon modules
- Replace string-quoted type hints with real imports and real annotations where possible
- Add postponed annotation evaluation where needed to keep imports safe on Python 3.9
- Verify core package imports still work without circular import errors

Refs #48

## Validation
- `python` import smoke test for `beacon`, `BacktestEngine`, `DriftThresholdModifier`, `IndexCalculator`, and `ETF`
- `pytest`
- `git diff --check`
